### PR TITLE
Ldz/mp 10677 android image read fix

### DIFF
--- a/android/src/main/java/nl/lightbase/PanoramaView.java
+++ b/android/src/main/java/nl/lightbase/PanoramaView.java
@@ -86,15 +86,7 @@ public class PanoramaView extends VrPanoramaView implements LifecycleEventListen
         }
     }
 
-    public void setDimensions(ReadableMap dimensions) {
-
-        imageWidth = dimensions.getInt("width");
-        imageHeight = dimensions.getInt("height");
-
-        //Log.i(LOG_TAG, "Image dimensions: " + imageWidth + ", " + imageHeight);
-
-    }
-
+    // TODO remove that
     public void setInputType(String inputType) {
         if(_inputType != null && _inputType.equals(inputType)){
             return;

--- a/android/src/main/java/nl/lightbase/PanoramaView.java
+++ b/android/src/main/java/nl/lightbase/PanoramaView.java
@@ -175,6 +175,10 @@ public class PanoramaView extends VrPanoramaView implements LifecycleEventListen
             Matrix matrix = new Matrix();
             matrix.postRotate(rotate);
 
+            if (rotate == 0) {
+                return bitmap;
+            }
+
             return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(),
                 bitmap.getHeight(), matrix, true);
         }

--- a/android/src/main/java/nl/lightbase/PanoramaViewManager.java
+++ b/android/src/main/java/nl/lightbase/PanoramaViewManager.java
@@ -74,16 +74,6 @@ public class PanoramaViewManager extends SimpleViewManager<PanoramaView> {
         view.setImageSource(value);
     }
 
-    @ReactProp(name = "dimensions")
-    public void setDimensions(PanoramaView view, ReadableMap dimensions) {
-        view.setDimensions(dimensions);
-    }
-
-    @ReactProp(name = "inputType")
-    public void setInputType(PanoramaView view, String inputType) {
-        view.setInputType(inputType);
-    }
-
     @ReactProp(name = "enableTouchTracking")
     public void setEnableTouchTracking(PanoramaView view, boolean enableTouchTracking) {
         view.setEnableTouchTracking(enableTouchTracking);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,6 @@ import { requireNativeComponent, ViewStyle, Platform } from "react-native";
 
 export type PanoramaViewProps = {
   imageUrl: string;
-  dimensions?: { width: number; height: number }; // Android-only
-  inputType?: "mono" | "stereo"; // Android-only
   enableTouchTracking?: boolean;
   onImageLoadingFailed?: () => void;
   onImageDownloaded?: () => void;
@@ -16,8 +14,6 @@ export const PanoramaView: React.FC<PanoramaViewProps> = ({
   onImageLoadingFailed,
   onImageDownloaded,
   onImageLoaded,
-  dimensions,
-  inputType,
   ...props
 }) => {
   const _onImageLoadingFailed = () => {
@@ -38,20 +34,9 @@ export const PanoramaView: React.FC<PanoramaViewProps> = ({
     }
   };
 
-  if (Platform.OS === "android" && !dimensions) {
-    console.warn('The "dimensions" property is required for PanoramaView on Android devices.');
-    return null;
-  }
-
-  if (Platform.OS === "ios" && inputType === "stereo") {
-    console.warn("The stereo inputType is currently only supported on Android devices.");
-  }
-
   return (
     <NativePanoramaView
       {...props}
-      dimensions={dimensions}
-      inputType={inputType}
       onImageDownloaded={_onImageDownloaded}
       onImageLoaded={_onImageLoaded}
       onImageLoadingFailed={_onImageLoadingFailed}


### PR DESCRIPTION
Updating the react native panorama to match our different cases :
1/ Rotate the image on read depending on the exif to feed the proper data to the native viewer.
2/ Automatically detect if the image is spherical or cylindrical depending on the dimensions of the image.
3/ Removed the two android specific props that are no longer needed because of 1/ and 2/